### PR TITLE
Add health check page for Azure API management instance

### DIFF
--- a/src/components/health-check/healthCheck.ts
+++ b/src/components/health-check/healthCheck.ts
@@ -1,0 +1,21 @@
+import { ApiService } from "../../services/apiService";
+
+export class HealthCheck {
+    private apiService: ApiService;
+
+    constructor(apiService: ApiService) {
+        this.apiService = apiService;
+    }
+
+    public async fetchHealthCheckData(): Promise<HealthCheckData> {
+        const healthCheckData = await this.apiService.getHealthCheckData();
+        return healthCheckData;
+    }
+}
+
+export interface HealthCheckData {
+    status: string;
+    uptimePercentage: number;
+    timestamp: Date;
+    message?: string;
+}

--- a/src/components/health-check/ko/healthCheck.html
+++ b/src/components/health-check/ko/healthCheck.html
@@ -1,0 +1,12 @@
+<div>
+    <h2>Health Check Status</h2>
+    <div data-bind="barChart: healthCheckData"></div>
+    <div>
+        <h3>Uptime Percentage</h3>
+        <p data-bind="text: uptimePercentage"></p>
+    </div>
+    <div>
+        <h3>Status Message</h3>
+        <p data-bind="text: statusMessage"></p>
+    </div>
+</div>

--- a/src/components/health-check/ko/healthCheckEditor.html
+++ b/src/components/health-check/ko/healthCheckEditor.html
@@ -1,0 +1,7 @@
+<div>
+    <h2>Health Check Status Editor</h2>
+    <div>
+        <label for="statusMessage">Status Message:</label>
+        <input type="text" id="statusMessage" data-bind="value: statusMessage" />
+    </div>
+</div>

--- a/src/components/health-check/ko/healthCheckEditor.ts
+++ b/src/components/health-check/ko/healthCheckEditor.ts
@@ -1,0 +1,9 @@
+import * as ko from "knockout";
+
+export class HealthCheckEditorViewModel {
+    public statusMessage: ko.Observable<string>;
+
+    constructor() {
+        this.statusMessage = ko.observable<string>();
+    }
+}

--- a/src/components/health-check/ko/healthCheckViewModel.ts
+++ b/src/components/health-check/ko/healthCheckViewModel.ts
@@ -1,0 +1,69 @@
+import * as ko from "knockout";
+import { HealthCheckData, HealthCheck } from "../healthCheck";
+import * as d3 from "d3";
+
+export class HealthCheckViewModel {
+    public healthCheckData: ko.Observable<HealthCheckData>;
+    public uptimePercentage: ko.Observable<number>;
+    public statusMessage: ko.Observable<string>;
+
+    constructor(private readonly healthCheck: HealthCheck) {
+        this.healthCheckData = ko.observable<HealthCheckData>();
+        this.uptimePercentage = ko.observable<number>();
+        this.statusMessage = ko.observable<string>();
+    }
+
+    public async loadHealthCheckData(): Promise<void> {
+        const data = await this.healthCheck.fetchHealthCheckData();
+        this.healthCheckData(data);
+        this.uptimePercentage(data.uptimePercentage);
+        this.statusMessage(data.message);
+        this.renderGraph(data);
+    }
+
+    private renderGraph(data: HealthCheckData): void {
+        const width = 700;
+        const height = 380;
+        const margin = { top: 20, right: 0, bottom: 30, left: 70 };
+        const barWidth = 10;
+        const fontSize = 15;
+
+        const svg = d3
+            .select("div[data-bind='barChart: healthCheckData']")
+            .append("svg")
+            .attr("viewBox", `0 0 ${width} ${height}`);
+
+        const x = d3.scaleTime()
+            .domain([new Date(data.timestamp.getTime() - 24 * 60 * 60 * 1000), data.timestamp])
+            .range([margin.left, width - margin.right]);
+
+        const y = d3.scaleLinear()
+            .domain([0, 100])
+            .nice()
+            .range([height - margin.bottom, margin.top]);
+
+        const xAxis = g => g
+            .attr("transform", `translate(0, ${height - margin.bottom})`)
+            .style("font-size", fontSize)
+            .call(d3.axisBottom(x).ticks(5).tickSizeOuter(0));
+
+        const yAxis = g => g
+            .attr("transform", `translate(${margin.left},0)`)
+            .style("font-size", fontSize)
+            .call(d3.axisLeft(y).ticks(5))
+            .call(g => g.select(".domain").remove());
+
+        svg.append("g").call(xAxis);
+        svg.append("g").call(yAxis);
+
+        svg.append("g")
+            .attr("fill", "#1786d8")
+            .selectAll("rect")
+            .data([data])
+            .join("rect")
+            .attr("x", d => x(d.timestamp) - barWidth / 2)
+            .attr("y", d => y(d.uptimePercentage))
+            .attr("height", d => y(0) - y(d.uptimePercentage))
+            .attr("width", barWidth);
+    }
+}

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -550,4 +550,19 @@ export class ApiService {
 
         return hostnameValues;
     }
+
+    /**
+     * Fetches health check data from the backend.
+     */
+    public async getHealthCheckData(): Promise<HealthCheckData> {
+        const healthCheckData = await this.mapiClient.get<HealthCheckData>("/healthcheck", [await this.mapiClient.getPortalHeader("getHealthCheckData")]);
+        return healthCheckData;
+    }
+}
+
+export interface HealthCheckData {
+    status: string;
+    uptimePercentage: number;
+    timestamp: Date;
+    message?: string;
 }


### PR DESCRIPTION
/AI generated/
Add a new page to display the health check status of an Azure API management instance as a graph and uptime percentage, and optionally allow writing a status message.

* **New Component and View Model**
  * Add `src/components/health-check/healthCheck.ts` to fetch health check data from the backend.
  * Add `src/components/health-check/ko/healthCheckViewModel.ts` to bind the data to the view and render the graph using d3.

* **New Views**
  * Add `src/components/health-check/ko/healthCheck.html` to display the health check status as a graph and uptime percentage.
  * Add `src/components/health-check/ko/healthCheckEditor.html` to allow writing a status message.

* **Service Method**
  * Modify `src/services/apiService.ts` to add a new method for fetching health check data from the backend.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kridah/api-management-developer-portal/pull/2?shareId=4d7a5d8f-177a-42e6-ad1b-ab9da2e2f897).